### PR TITLE
Reduce log_severity to LOGSEVERITY_DEFAULT

### DIFF
--- a/html_chromium/ChromiumSystem.cpp
+++ b/html_chromium/ChromiumSystem.cpp
@@ -108,7 +108,7 @@ bool ChromiumSystem::Init( const char* pBaseDir, IHtmlResourceHandler* pResource
 	settings.no_sandbox = false;
 #endif
 	settings.command_line_args_disabled = true;
-	settings.log_severity = LOGSEVERITY_VERBOSE;
+	settings.log_severity = LOGSEVERITY_DEFAULT;
 
 #ifdef _WIN32
 	// Chromium will be sad if we don't resolve any NTFS junctions for it


### PR DESCRIPTION
LOGSEVERITY_VERBOSE is creating huge log files for clients on x86-64. Over time, they can become multiple GBs in size.