### PR TITLE
Add svg mime type

### DIFF
--- a/html_chromium/ResourceHandler.cpp
+++ b/html_chromium/ResourceHandler.cpp
@@ -90,6 +90,7 @@ void ResourceHandler::GetResponseHeaders( CefRefPtr<CefResponse> response, cef_i
 	else if ( ext == "jpeg" ) mimeType = "image/jpg";
 	else if ( ext == "css" ) mimeType = "text/css";
 	else if ( ext == "js" ) mimeType = "text/javascript";
+	else if ( ext == "svg" ) mimeType = "image/svg+xml";
 
 	response->SetStatus( 200 );
 	response->SetMimeType( mimeType );


### PR DESCRIPTION
Svg images can't be used in `<img>` or in CSS unless the server specifies the correct svg mime type. 
asset:// svg files were being specified as "text/html" which prevents them working. This PR fixes that.

An example of a benefit would be svg images for certain menu images and potentially gamemode icons. They scale for use at any size, for example instead of fixed-size 16x11 flags could be any size and still look good. And they are future-proof for if Gmod becomes DPI-aware in future and enables it in CEF, for example the 16x16 favourite heart becomes blurry when DPI-scaled but a svg displayed at 16x16 would stay good when DPI-scaled.

16px width comparison between 16x11 png and infinite size svg
<img width="16" alt="(png)" src="https://github.com/user-attachments/assets/ec03a3b4-c920-41a7-865c-16138e44dd22" /> <img width="16" alt="(svg)" src="https://raw.githubusercontent.com/jdecked/twemoji/refs/heads/main/assets/svg/1f3f4-200d-2620-fe0f.svg" />
24px width
<img width="24" alt="(png)" src="https://github.com/user-attachments/assets/ec03a3b4-c920-41a7-865c-16138e44dd22" /> <img width="24" alt="(svg)" src="https://raw.githubusercontent.com/jdecked/twemoji/refs/heads/main/assets/svg/1f3f4-200d-2620-fe0f.svg" />
42px width
<img width="42" alt="(png)" src="https://github.com/user-attachments/assets/ec03a3b4-c920-41a7-865c-16138e44dd22" /> <img width="42" alt="(svg)" src="https://raw.githubusercontent.com/jdecked/twemoji/refs/heads/main/assets/svg/1f3f4-200d-2620-fe0f.svg" />
100px width
<img width="100" alt="(png)" src="https://github.com/user-attachments/assets/ec03a3b4-c920-41a7-865c-16138e44dd22" /> <img width="100" alt="(svg)" src="https://raw.githubusercontent.com/jdecked/twemoji/refs/heads/main/assets/svg/1f3f4-200d-2620-fe0f.svg" />
400px width
<img width="400" alt="(png)" src="https://github.com/user-attachments/assets/ec03a3b4-c920-41a7-865c-16138e44dd22" /> <img width="400" alt="(svg)" src="https://raw.githubusercontent.com/jdecked/twemoji/refs/heads/main/assets/svg/1f3f4-200d-2620-fe0f.svg" />

Github limits image width to 100% of the post container, so if you're on a mobile device the above might not be the exact size noted.