### PR TITLE
[rebase-progressive] Fix/Cleanup CMake files, Fix building with CMake on macOS and Linux, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,22 @@
-# The directory I like to build under
+# Common build directories
 /build
+/build_x64
+/build_x86
+
+# Distribution directories
+/dist
+/syms
 
 # Dependencies that are downloaded/installed separately
-/thirdparty/cef3/*
+/thirdparty/cef3/**
 !/thirdparty/cef3/README.txt
+
+# IDE files
+/.vscode
+/.idea
+
+# Misc OS files
+**/.DS_Store
+
+# direnv
+/.direnv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,99 +1,94 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Required for MSVC_RUNTIME_LIBRARY
 if(WIN32)
-	# Required for MSVC_RUNTIME_LIBRARY
-	cmake_minimum_required(VERSION 3.15)
 	cmake_policy(SET CMP0091 NEW)
-else()
-	cmake_minimum_required(VERSION 2.8.7)
 endif()
 
-project(gmod-html LANGUAGES CXX)
+project(gmod_html)
 
 # We can only do release builds
 set(CMAKE_CONFIGURATION_TYPES Release Debug)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Match GMod and our prebuilt libraries
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+set_property(GLOBAL PROPERTY OS_FOLDERS ON)
 
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	set(CMAKE_INSTALL_PREFIX  ${CMAKE_CURRENT_BINARY_DIR}/bin CACHE PATH "..." FORCE)
-endif()
+set(CEF_VERSION "86.0.24+g85e79d4+chromium-86.0.4240.198")
 
-if(WIN32)
-	if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
-		set(GAME_BIN_DIR .)
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+	if("${PROJECT_ARCH}" STREQUAL "arm64")
+		set(CEF_PLATFORM "macosarm64")
 	else()
-		set(GAME_BIN_DIR win64)
+		set(CEF_PLATFORM "macosx64")
 	endif()
-elseif(UNIX AND NOT APPLE)
-	set(GAME_BIN_DIR linux64)
-else()
-	message(FATAL_ERROR "No GAME_DIR definition")
+elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+	if(CMAKE_SIZEOF_VOID_P MATCHES 8)
+		set(CEF_PLATFORM "linux64")
+	else()
+		set(CEF_PLATFORM "linux32")
+	endif()
+elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+	if(CMAKE_SIZEOF_VOID_P MATCHES 8)
+		set(CEF_PLATFORM "windows64")
+	else()
+		set(CEF_PLATFORM "windows32")
+	endif()
 endif()
-
-# Kind of lame but I'm having PDB timestamp mismatches
-set (CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin/${GAME_BIN_DIR})
-set (CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin/${GAME_BIN_DIR})
-set (CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin/${GAME_BIN_DIR})
-set (CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin/${GAME_BIN_DIR})
-
-# ImGui
-add_subdirectory(thirdparty/imgui-1.74)
 
 # glad
-add_subdirectory(thirdparty/glad)
+add_subdirectory(thirdparty/glad EXCLUDE_FROM_ALL)
+
+# ImGui
+add_subdirectory(thirdparty/imgui-1.74 EXCLUDE_FROM_ALL)
 
 # GLFW
 set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-add_subdirectory(thirdparty/glfw-3.3.2)
+add_subdirectory(thirdparty/glfw-3.3.2 EXCLUDE_FROM_ALL)
 
 # Chromium Project
-if(WIN32)
-	if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
-		set(CEF_PATH ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cef3/cef_binary_80.0.4+g74f7b0c+chromium-80.0.3987.122_windows32)
-	else()
-		set(CEF_PATH ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cef3/cef_binary_80.0.4+g74f7b0c+chromium-80.0.3987.122_windows64)
-	endif()
-elseif(UNIX AND NOT APPLE)
-	set(CEF_PATH ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cef3/cef_binary_80.0.4+g74f7b0c+chromium-80.0.3987.122_linux64)
-	add_definitions(-DPOSIX -DLINUX)
+set(CEF_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cef3/cef_binary_${CEF_VERSION}_${CEF_PLATFORM}")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CEF_ROOT}/cmake")
+
+# OS_WINDOWS, OS_LINUX, and OS_MAC are defined in cef_variables.cmake
+find_package(CEF REQUIRED)
+
+if(GEN_NINJA OR GEN_MAKEFILES)
+	set(CEF_TARGET_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/out/${CMAKE_BUILD_TYPE}/${CEF_PLATFORM}")
+	set(INSTALL_OUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/dist/${CEF_PLATFORM}-${CMAKE_BUILD_TYPE}")
 else()
-	message(FATAL_ERROR "No CEF_PATH")
+	set(CEF_TARGET_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/out/$<CONFIGURATION>/${CEF_PLATFORM}")
+	set(INSTALL_OUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/dist/${CEF_PLATFORM}-$<CONFIGURATION>")
 endif()
+set(CEF_TARGET_OUT_DIR ${CEF_TARGET_OUT_DIR}/bin/${CEF_PLATFORM})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CEF_TARGET_OUT_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CEF_TARGET_OUT_DIR})
 
-add_subdirectory(${CEF_PATH} EXCLUDE_FROM_ALL)
+add_subdirectory(${CEF_LIBCEF_DLL_WRAPPER_PATH} libcef_dll_wrapper EXCLUDE_FROM_ALL)
 
-# Chromium Import Lib
-add_library(libcef_imp SHARED IMPORTED)
+add_subdirectory(${CEF_ROOT}/tests/cefclient EXCLUDE_FROM_ALL)
+add_subdirectory(${CEF_ROOT}/tests/cefsimple EXCLUDE_FROM_ALL)
+add_subdirectory(${CEF_ROOT}/tests/gtest EXCLUDE_FROM_ALL)
+add_subdirectory(${CEF_ROOT}/tests/ceftests EXCLUDE_FROM_ALL)
 
-if(WIN32)
-	set_target_properties(libcef_imp PROPERTIES IMPORTED_LOCATION ${CEF_PATH}/Release/libcef.dll)
-	set_target_properties(libcef_imp PROPERTIES IMPORTED_IMPLIB ${CEF_PATH}/Release/libcef.lib)
-elseif(UNIX AND NOT APPLE)
-	set_target_properties(libcef_imp PROPERTIES IMPORTED_LOCATION ${CEF_PATH}/Release/libcef.so)
-else()
-	message(FATAL_ERROR "No libcef_imp import library set")
-endif()
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-# Chromium Sandbox
-add_library(cef_sandbox STATIC IMPORTED)
-
-if(WIN32)
-	set_target_properties(cef_sandbox PROPERTIES IMPORTED_LOCATION ${CEF_PATH}/Release/cef_sandbox.lib)
-else()
-	message(FATAL_ERROR "No cef_sandbox library set")
-endif()
+# Match GMod and our prebuilt libraries
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # Our projects
-add_subdirectory(example_host)
 add_subdirectory(html)
-add_subdirectory(html_stub)
+add_subdirectory(html_stub EXCLUDE_FROM_ALL)
 add_subdirectory(html_chromium)
 
-if(UNIX)
+if(OS_LINUX OR OS_MAC)
 	add_subdirectory(html_chromium/chromium_process)
 endif()
+
+# Disabled for now
+#add_subdirectory(example_host EXCLUDE_FROM_ALL)
+
+PRINT_CEF_CONFIG()

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 This is pretty much just an abstraction layer around The Chromium Embedded Framework (https://bitbucket.org/chromiumembedded/cef)
 
 ## Chromium Embedded Framework Binary Distribution
-To work with this project you will need a build of the Chromium Embedded Framework. You can download the builds used by Garry's Mod here if you don't want to compile your own:
+To work with this project you will need a build of the Chromium Embedded Framework. You can download prebuilt versions of CEF from Spotify's Automated Builder if you don't want to compile your own:
 
-| Platform | URL |
-| -------- | --- |
-| Windows x86 | https://files.facepunch.com/willox/7bb55f57-7c70-4140-83d7-2d61d8b57816/cef_binary_80.0.4%2Bg74f7b0c%2Bchromium-80.0.3987.122_windows32.tar.bz2 |
-| Windows x64 | https://files.facepunch.com/willox/14ceed65-8809-4fba-97a7-2d524b6d45ec/cef_binary_80.0.4%2Bg74f7b0c%2Bchromium-80.0.3987.122_windows64.tar.bz2 |
-| Linux x64 | https://files.facepunch.com/willox/dfd5d7fe-2184-40a9-90b0-49f9eef9a9b5/cef_binary_80.0.4%2Bg74f7b0c%2Bchromium-80.0.3987.122_linux64.tar.bz2 |
-| macOS x64 | https://files.facepunch.com/willox/17e19274-4112-4734-ac20-22cd8644bcb4/cef_binary_80.0.4%2Bg74f7b0c%2Bchromium-80.0.3987.122_macosx64.tar.bz2 |
+https://cef-builds.spotifycdn.com/index.html
 
-These belong in the `./thirdparty/cef3/` directory (after extraction.) The paths are currently hardcoded into the root `CMakelists.txt` file.
+Everything you need is in the **Standard Distribution**. If you need to debug the CEF part, grab the Symbols too. The extracted binary folder belongs in the `./thirdparty/cef3/` directory. The paths are currently hardcoded into the root `CMakelists.txt` file.
+
+## Currently supported CEF version
+The current version of CEF that's supported by this library is:
+
+- **86.0.24+g85e79d4+chromium-86.0.4240.198**
+
+This is not the only version that could be supported, but it's the version that's currently configured and tested to work.
 
 ## Getting started
 ### Windows
@@ -32,28 +34,49 @@ cd build_x64
 cmake -G "Visual Studio 16 2019" -A x64 ..
 ```
 
-After running either of these sets of commands, you can enter your created directory and open the `gmod-html.sln` solution in Visual Studio. Compiling the `INSTALL` project will place a complete build into `<your_build_dir>/bin` by default.
+After running either of these sets of commands, you can enter your created directory and open the `gmod-html.sln` solution in Visual Studio. Compiling the `INSTALL` project will place a complete build into the `dist/` folder by default.
+
+If you only have VS Build Tools, use this command in "Developer Command Prompt for VS 2019":
+```
+msbuild /p:Configuration=Release INSTALL.vcxproj
+```
 
 ### Linux
 #### Requirements
 - A version of GCC/G++ or Clang/Clang++ with C++11 support
-- CMake 2.8.7 or newer
+- CMake 3.15 or newer
 
 #### Compiling
 ```sh
 mkdir build
 cd build
-cmake -G "Unix Makefiles" ..
+cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release -D CMAKE_POLICY_VERSION_MINIMUM=3.5 ..
 make && make install
 ```
 
-This will place a complete build into `build/bin` by default.
+This will place a complete build into the `dist` folder by default.
 
 ### macOS
-Todo
+#### Requirements
+- Ninja
+- CMake 3.15 or newer
+
+#### Compiling
+```sh
+mkdir build
+cd build
+cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D CMAKE_POLICY_VERSION_MINIMUM=3.5 ..
+ninja && ninja install
+```
+
+##### Apple Silicon
+```sh
+cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D CMAKE_POLICY_VERSION_MINIMUM=3.5 -D CMAKE_APPLE_SILICON_PROCESSOR=x86_64 ..
+```
+
+This will place a complete build into the `dist` folder by default.
 
 ## TODO
-- Improve the CMake files. We don't use them for GMod builds so they're a bit wonky.
 - Get the example_host into workable condition. It's disabled at the moment
 - Cleanup. Everything is quite messy.
 - macOS. These builds require quite a few unique things so they're not handled by the CMake scripts at all at the moment. It's still technically possible to get the builds working, though.

--- a/example_host/CMakeLists.txt
+++ b/example_host/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(TARGET example_host)
 set(SOURCES
 	Main.cpp
 	Window.cpp
@@ -9,36 +10,14 @@ set(SOURCES
 	HtmlPanel.cpp
 	HtmlPanel.h)
 
-if(WIN32)
-	set(SOURCES
-		${SOURCES}
-		../html_chromium/chromium_process/ChromiumApp.cpp
-		../html_chromium/chromium_process/ChromiumApp.h
-		../html_chromium/chromium_process/Windows.cpp)
-endif()
+add_executable(${TARGET} ${SOURCES})
+SET_EXECUTABLE_TARGET_PROPERTIES(${TARGET})
 
-# Lame
-include_directories(${CEF_PATH})
+add_dependencies(${TARGET} html_chromium html chromium_process glfw glad imgui)
+target_compile_definitions(${TARGET} PRIVATE IMGUI_IMPL_OPENGL_LOADER_GLAD)
+target_link_libraries(${TARGET} glfw glad imgui html)
 
-add_executable(example_host WIN32 ${SOURCES})
-target_link_libraries(example_host glfw glad imgui html libcef_imp libcef_dll_wrapper)
-target_link_libraries(example_host optimized cef_sandbox)
-
-if(WIN32)
-	target_link_libraries(example_host
-		shlwapi
-		winmm
-		wsock32
-		comctl32
-		rpcrt4
-		version
-		DbgHelp
-		Psapi
-		wbemuuid
-		OleAut32
-		SetupAPI
-		Propsys
-		Cfgmgr32
-		PowrProf
-		Delayimp.lib)
+if(OS_LINUX)
+	set_target_properties(${TARGET} PROPERTIES INSTALL_RPATH "$ORIGIN")
+	set_target_properties(${TARGET} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 endif()

--- a/html/html/JSValue.h
+++ b/html/html/JSValue.h
@@ -50,6 +50,7 @@ public:
 
 	JSValue()
 		: _type( Type::Undefined )
+		, _bool( false )
 	{}
 
 	JSValue( bool value )
@@ -79,6 +80,7 @@ public:
 
 	JSValue( const JSValue& other )
 		: _type( other._type )
+		, _bool( false )
 	{
 		switch ( _type )
 		{
@@ -104,6 +106,7 @@ public:
 
 	JSValue( JSValue&& other ) noexcept
 		: _type( other._type )
+		, _bool( false )
 	{
 		switch ( _type )
 		{
@@ -237,17 +240,17 @@ public:
 
 	//
 
-	const bool HashMap_Begin( const char*& pKey, size_t& keySize, const JSValue*& pValue ) const
+	bool HashMap_Begin( const char*& pKey, size_t& keySize, const JSValue*& pValue ) const
 	{
 		return _pHashMap->Begin( pKey, keySize, pValue );
 	}
 
-	const bool HashMap_Next( const char*& pKey, size_t& keySize, const JSValue*& pValue ) const
+	bool HashMap_Next( const char*& pKey, size_t& keySize, const JSValue*& pValue ) const
 	{
 		return _pHashMap->Next( pKey, keySize, pValue );
 	}
 
-	const size_t HashMap_Size() const
+	size_t HashMap_Size() const
 	{
 		return _pHashMap->Size();
 	}

--- a/html_chromium/CMakeLists.txt
+++ b/html_chromium/CMakeLists.txt
@@ -1,38 +1,4 @@
-if(WIN32)
-	set(BINARIES
-		${CEF_PATH}/Release/chrome_elf.dll
-		${CEF_PATH}/Release/d3dcompiler_47.dll
-		${CEF_PATH}/Release/libcef.dll
-		${CEF_PATH}/Release/libEGL.dll
-		${CEF_PATH}/Release/libGLESv2.dll
-		${CEF_PATH}/Release/snapshot_blob.bin
-		${CEF_PATH}/Release/v8_context_snapshot.bin
-		${CEF_PATH}/Resources/icudtl.dat)
-elseif(UNIX AND NOT APPLE)
-	set(BINARIES
-		${CEF_PATH}/Release/chrome-sandbox
-		${CEF_PATH}/Release/libcef.so
-		${CEF_PATH}/Release/libEGL.so
-		${CEF_PATH}/Release/libGLESv2.so
-		${CEF_PATH}/Release/snapshot_blob.bin
-		${CEF_PATH}/Release/v8_context_snapshot.bin
-		${CEF_PATH}/Resources/icudtl.dat)
-else()
-	message(FATAL_ERROR "No IMPORTED_LOCATION for libcef")
-endif()
-
-set(RESOURCES
-	${CEF_PATH}/Resources/cef.pak
-	${CEF_PATH}/Resources/cef_100_percent.pak
-	${CEF_PATH}/Resources/cef_200_percent.pak
-	${CEF_PATH}/Resources/cef_extensions.pak
-	${CEF_PATH}/Resources/devtools_resources.pak)
-
-install(FILES ${BINARIES} DESTINATION ${GAME_BIN_DIR})
-install(FILES ${RESOURCES} DESTINATION ${CMAKE_BINARY_DIR}/bin/chromium)
-install(DIRECTORY ${CEF_PATH}/Resources/locales DESTINATION ${CMAKE_BINARY_DIR}/bin/chromium)
-
-# Actual lib
+set(TARGET html_chromium)
 set(SOURCES
 	cef_end.h
 	cef_start.h
@@ -51,9 +17,43 @@ set(SOURCES
 	ResourceHandler.cpp
 	ResourceHandler.h)
 
-# Lame
-include_directories(${CEF_PATH})
+if(OS_LINUX OR OS_WINDOWS)
+	ADD_LOGICAL_TARGET("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
+endif()
 
-add_library(html_chromium SHARED ${SOURCES})
-target_link_libraries(html_chromium html libcef_imp libcef_dll_wrapper)
-SET_TARGET_PROPERTIES(html_chromium PROPERTIES PREFIX "")
+add_library(${TARGET} SHARED ${SOURCES})
+SET_LIBRARY_TARGET_PROPERTIES(${TARGET})
+add_dependencies(${TARGET} html libcef_dll_wrapper)
+
+if(OS_MAC)
+	target_link_libraries(${TARGET} html libcef_dll_wrapper ${CEF_STANDARD_LIBS})
+else()
+	target_link_libraries(${TARGET} html libcef_lib libcef_dll_wrapper ${CEF_STANDARD_LIBS})
+endif()
+
+if(OS_WINDOWS AND USE_SANDBOX)
+	ADD_LOGICAL_TARGET("cef_sandbox_lib" "${CEF_SANDBOX_LIB_DEBUG}" "${CEF_SANDBOX_LIB_RELEASE}")
+	target_link_libraries(${TARGET} cef_sandbox_lib ${CEF_SANDBOX_STANDARD_LIBS})
+endif()
+
+set_target_properties(${TARGET} PROPERTIES PREFIX "")
+if(OS_LINUX)
+	set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME "html_chromium_client")
+endif()
+
+if(OS_WINDOWS)
+	if(CMAKE_SIZEOF_VOID_P MATCHES 8)
+		install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod/bin/win64")
+		COPY_FILES(${TARGET} "icudtl.dat" "${CEF_RESOURCE_DIR}" "${INSTALL_OUT_DIR}/GarrysMod/bin/win64")
+		COPY_FILES(${TARGET} "${CEF_BINARY_FILES}" "${CEF_BINARY_DIR}" "${INSTALL_OUT_DIR}/GarrysMod/bin/win64")
+	else()
+		install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod/bin")
+		COPY_FILES(${TARGET} "icudtl.dat" "${CEF_RESOURCE_DIR}" "${INSTALL_OUT_DIR}/GarrysMod/bin")
+		COPY_FILES(${TARGET} "${CEF_BINARY_FILES}" "${CEF_BINARY_DIR}" "${INSTALL_OUT_DIR}/GarrysMod/bin")
+	endif()
+	COPY_FILES(${TARGET} "${CEF_RESOURCE_FILES}" "${CEF_RESOURCE_DIR}" "${INSTALL_OUT_DIR}/GarrysMod/bin/chromium")
+elseif(OS_LINUX)
+	install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod/bin/${CEF_PLATFORM}")
+elseif(OS_MAC)
+	install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod_Signed.app/Contents/MacOS")
+endif()

--- a/html_chromium/ChromiumBrowser.cpp
+++ b/html_chromium/ChromiumBrowser.cpp
@@ -7,6 +7,10 @@
 #include "include/cef_parser.h"
 #include "cef_end.h"
 
+#ifdef _WIN32
+	#include <shellapi.h>
+#endif
+
 static bool CefValueToJSValue( JSValue& outValue, CefRefPtr<CefValue> inValue, int depth = 0 )
 {
 	if ( depth > 16 )
@@ -222,10 +226,10 @@ static int GetModifiers( const IHtmlClient::EventModifiers modifiers )
 ChromiumBrowser::ChromiumBrowser()
 	: m_Wide( 512 )
 	, m_Tall( 512 )
-	, m_PopupWide( 0 )
-	, m_PopupTall( 0 )
 	, m_PopupX( 0 )
 	, m_PopupY( 0 )
+	, m_PopupWide( 0 )
+	, m_PopupTall( 0 )
 	, m_PopupData( nullptr )
 	, m_OpenLinksExternally( false )
 {}
@@ -283,7 +287,7 @@ void ChromiumBrowser::SendKeyEvent( IHtmlClient::KeyEvent keyEvent )
 			chromiumKeyEvent.type = KEYEVENT_CHAR;
 			chromiumKeyEvent.character = static_cast<char16>( keyEvent.key_char );
 			chromiumKeyEvent.unmodified_character = static_cast<char16>( keyEvent.key_char );
-#ifdef OSX
+#ifdef __APPLE__
 			chromiumKeyEvent.windows_key_code = 0;
 #else
 			chromiumKeyEvent.windows_key_code = keyEvent.windows_key_code;
@@ -786,7 +790,7 @@ bool ChromiumBrowser::OnBeforeBrowse( CefRefPtr<CefBrowser>,
 	if ( m_OpenLinksExternally )
 	{
 #if defined( _WIN32 )
-		ShellExecute( NULL, "open", request->GetURL().ToString().c_str(), NULL, NULL, SW_SHOWNORMAL );
+		ShellExecuteA( NULL, "open", request->GetURL().ToString().c_str(), NULL, NULL, SW_SHOWNORMAL );
 #elif defined( __linux__ )
 		std::string strUrl = request->GetURL().ToString();
 		pid_t pid;

--- a/html_chromium/ChromiumClient.h
+++ b/html_chromium/ChromiumClient.h
@@ -11,7 +11,7 @@ class ChromiumBrowser;
 //
 // This class just handles threaded communication to/from the ChromiumBrowser instance
 //
-class ChromiumClient
+class ChromiumClient final
 	: public IHtmlClient
 {
 public:

--- a/html_chromium/chromium_process/CMakeLists.txt
+++ b/html_chromium/chromium_process/CMakeLists.txt
@@ -1,16 +1,81 @@
+set(TARGET chromium_process)
 set(SOURCES
 	ChromiumApp.cpp
 	ChromiumApp.h)
+set(RESOURCES )
 
-if(UNIX AND NOT APPLE)
-	set(SOURCES ${SOURCES} Linux.cpp)
+set(SOURCES_LINUX Linux.cpp)
+set(SOURCES_MAC macOS.cpp)
+
+APPEND_PLATFORM_SOURCES(SOURCES)
+APPEND_PLATFORM_SOURCES(RESOURCES)
+
+if(OS_LINUX)
+	ADD_LOGICAL_TARGET("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
+
+	add_executable(${TARGET} ${SOURCES})
+
+	SET_EXECUTABLE_TARGET_PROPERTIES(${TARGET})
+	add_dependencies(${TARGET} libcef_dll_wrapper)
+
+	target_link_libraries(${TARGET} libcef_lib libcef_dll_wrapper ${CEF_STANDARD_LIBS})
+
+	install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod/bin/${CEF_PLATFORM}")
+	set_target_properties(${TARGET} PROPERTIES INSTALL_RPATH "$ORIGIN")
+	set_target_properties(${TARGET} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
+
+	# FIXME: These should be moved to their own target
+	LIST(REMOVE_ITEM CEF_RESOURCE_FILES "icudtl.dat")
+	COPY_FILES(${TARGET} "icudtl.dat" "${CEF_RESOURCE_DIR}" "${INSTALL_OUT_DIR}/GarrysMod/bin/${CEF_PLATFORM}")
+	COPY_FILES(${TARGET} "${CEF_BINARY_FILES}" "${CEF_BINARY_DIR}" "${INSTALL_OUT_DIR}/GarrysMod/bin/${CEF_PLATFORM}")
+	COPY_FILES(${TARGET} "${CEF_RESOURCE_FILES}" "${CEF_RESOURCE_DIR}" "${INSTALL_OUT_DIR}/GarrysMod/bin/linux32/chromium")
+elseif(OS_MAC)
+	set(HELPER_TARGET "gmod_Helper")
+	set(HELPER_OUTPUT_NAME "gmod Helper")
+	add_custom_target(${TARGET} ALL)
+
+	if(USE_SANDBOX)
+		ADD_LOGICAL_TARGET("cef_sandbox_lib" "${CEF_SANDBOX_LIB_DEBUG}" "${CEF_SANDBOX_LIB_RELEASE}")
+	endif()
+
+	add_custom_command(
+		TARGET ${TARGET}
+		POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_directory
+						"${CEF_BINARY_DIR}/Chromium Embedded Framework.framework"
+						"${INSTALL_OUT_DIR}/GarrysMod_Signed.app/Contents/Frameworks/Chromium Embedded Framework.framework"
+		VERBATIM)
+
+	foreach(_suffix_list ${CEF_HELPER_APP_SUFFIXES})
+		string(REPLACE ":" ";" _suffix_list ${_suffix_list})
+		list(GET _suffix_list 0 _name_suffix)
+		list(GET _suffix_list 1 _target_suffix)
+		list(GET _suffix_list 2 _plist_suffix)
+
+		set(_helper_target "${HELPER_TARGET}${_target_suffix}")
+		set(_helper_output_name "${HELPER_OUTPUT_NAME}${_name_suffix}")
+
+		set(_helper_info_plist "${CMAKE_CURRENT_BINARY_DIR}/helper-Info${_target_suffix}.plist")
+		file(READ "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/helper-Info.plist" _plist_contents)
+		string(REPLACE "\${EXECUTABLE_NAME}" "${_helper_output_name}" _plist_contents ${_plist_contents})
+		string(REPLACE "\${PRODUCT_NAME}" "${_helper_output_name}" _plist_contents ${_plist_contents})
+		string(REPLACE "\${BUNDLE_ID_SUFFIX}" "${_plist_suffix}" _plist_contents ${_plist_contents})
+		file(WRITE ${_helper_info_plist} ${_plist_contents})
+
+		add_executable(${_helper_target} MACOSX_BUNDLE ${SOURCES})
+		SET_EXECUTABLE_TARGET_PROPERTIES(${_helper_target})
+		add_dependencies(${_helper_target} libcef_dll_wrapper)
+		target_link_libraries(${_helper_target} libcef_dll_wrapper ${CEF_STANDARD_LIBS})
+		set_target_properties(${_helper_target} PROPERTIES
+			MACOSX_BUNDLE_INFO_PLIST ${_helper_info_plist}
+			OUTPUT_NAME ${_helper_output_name})
+
+		install(TARGETS ${_helper_target} DESTINATION ${INSTALL_OUT_DIR}/GarrysMod_Signed.app/Contents/Frameworks)
+
+		if(USE_SANDBOX)
+			target_link_libraries(${_helper_target} cef_sandbox_lib)
+		endif()
+	endforeach()
 else()
 	message(FATAL_ERROR "No ChromiumApp Main implementation")
 endif()
-
-# Lame
-include_directories(${CEF_PATH})
-
-add_executable(chromium_process ${SOURCES})
-target_link_libraries(chromium_process libcef_imp libcef_dll_wrapper)
-install(TARGETS chromium_process RUNTIME DESTINATION ${GAME_BIN_DIR})

--- a/html_chromium/chromium_process/ChromiumApp.cpp
+++ b/html_chromium/chromium_process/ChromiumApp.cpp
@@ -177,11 +177,11 @@ void ChromiumApp::OnBeforeCommandLineProcessing( const CefString& process_type, 
 	command_line->AppendSwitch( "enable-system-flash" );
 
 	// This can interfere with posix signals and break Breakpad
-#ifdef POSIX
+#if defined( __APPLE__ ) || defined( __linux__ )
 	command_line->AppendSwitch( "disable-in-process-stack-traces" );
 #endif
 
-#ifdef OSX
+#ifdef __APPLE__
 		command_line->AppendSwitch( "use-mock-keychain" );
 #endif
 

--- a/html_chromium/chromium_process/resources/mac/helper-Info.plist
+++ b/html_chromium/chromium_process/resources/mac/helper-Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleDisplayName</key>
+		<string>${EXECUTABLE_NAME}</string>
+		<key>CFBundleExecutable</key>
+		<string>${EXECUTABLE_NAME}</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.facepunch.garrysmod_webhelper${BUNDLE_ID_SUFFIX}</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundleName</key>
+		<string>${PRODUCT_NAME}</string>
+		<key>CFBundlePackageType</key>
+		<string>APPL</string>
+		<key>CFBundleSignature</key>
+		<string>????</string>
+		<key>LSEnvironment</key>
+		<dict>
+			<key>MallocNanoZone</key>
+			<string>0</string>
+		</dict>
+		<key>LSFileQuarantineEnabled</key>
+		<true/>
+		<key>LSMinimumSystemVersion</key>
+		<string>10.11.0</string>
+		<key>LSUIElement</key>
+		<string>1</string>
+		<key>NSSupportsAutomaticGraphicsSwitching</key>
+		<true/>
+	</dict>
+</plist>

--- a/html_stub/CMakeLists.txt
+++ b/html_stub/CMakeLists.txt
@@ -1,9 +1,27 @@
+set(TARGET html_stub)
 set(SOURCES
 	StubClient.cpp
 	StubClient.h
 	StubSystem.cpp
 	StubSystem.h)
 
-add_library(html_stub SHARED ${SOURCES})
-target_link_libraries(html_stub html)
-SET_TARGET_PROPERTIES(html_stub PROPERTIES PREFIX "")
+add_library(${TARGET} SHARED ${SOURCES})
+add_dependencies(${TARGET} html)
+target_link_libraries(${TARGET} html)
+
+set_target_properties(${TARGET} PROPERTIES PREFIX "")
+if(OS_LINUX)
+	set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME "html_stub_client")
+endif()
+
+if(OS_WINDOWS)
+	if(CMAKE_SIZEOF_VOID_P MATCHES 8)
+		install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod/bin/win64")
+	else()
+		install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod/bin")
+	endif()
+elseif(OS_LINUX)
+	install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod/bin/${CEF_PLATFORM}")
+elseif(OS_MAC)
+	install(TARGETS ${TARGET} DESTINATION "${INSTALL_OUT_DIR}/GarrysMod_Signed.app/Contents/MacOS")
+endif()

--- a/thirdparty/cef3/README.txt
+++ b/thirdparty/cef3/README.txt
@@ -1,5 +1,4 @@
 Chromium binary distributions live in here. You can download them from:
-- https://files.facepunch.com/willox/3004a977-b227-4a20-bbfb-e698913d8a71/cef_binary_79.1.31%2Bgfc9ef34%2Bchromium-79.0.3945.117_linux64.tar.bz2
-- https://files.facepunch.com/willox/46c89e07-a257-4988-96e8-81e945284469/cef_binary_79.1.31%2Bgfc9ef34%2Bchromium-79.0.3945.117_windows32.tar.bz2
-- https://files.facepunch.com/willox/8750c07c-4888-4a79-8449-a01bd6e851f7/cef_binary_79.1.31%2Bgfc9ef34%2Bchromium-79.0.3945.117_windows64.tar.bz2
-- https://files.facepunch.com/willox/7fd05979-e9ad-4b94-8d85-0014bacb170c/cef_binary_79.1.35%2Bgfebbb4a%2Bchromium-79.0.3945.130_macosx64.tar.bz2
+https://cef-builds.spotifycdn.com/index.html
+
+See the top-level README.md for more info


### PR DESCRIPTION
The 2nd PR in the series from [SGS's gmod-html fork](https://github.com/solsticegamestudios/gmod-html).

### Changes in this PR
- Fix/Cleanup CMake files
- Structure CMake files correctly for a CEF project, importing CEF's CMake files
- Fix building with CMake on macOS and Linux
- Explicitly use -A Windows API functions (presence of UNICODE from CEF CMake forces consideration)
- Cleanup JSValue to fix macOS builds
- Use correct User Agent version on Linux and macOS
- Update README with working instructions to build using CMake on all platforms
- Update .gitignore to ignore all CMake build/dist directories, IDE files, recursively ignore thirdparty/cef3, etc
- Disable example_host (non-functional as-is and requires changes we'll do separately)

### Motivation for changes
These changes address problems attempting to compile gmod-html using CMake, which is the primary method used outside of Facepunch.

We restructure the CMake files as a proper CEF project, which addresses a whole host of issues by itself. Beyond that, these changes are the **absolute minimum** necessary for getting compilation to work with CMake on all platforms.

It must be noted that since there are no changes here that address issues *running* CEF post-compilation, it is still broken on Linux, however fixing that will require updating to a newer CEF version regardless.

This PR also includes working instructions for compiling with CMake on all platforms in the README.